### PR TITLE
Fix collections import warning

### DIFF
--- a/littleutils/__init__.py
+++ b/littleutils/__init__.py
@@ -20,7 +20,9 @@ try:
 except NameError:
     # noinspection PyShadowingBuiltins
     basestring = str
-from collections import Sized, defaultdict, Mapping, Sequence, MutableMapping
+
+from collections.abc import Sized, Mapping, Sequence, MutableMapping
+from collections import defaultdict
 from contextlib import contextmanager
 from datetime import datetime, date, time as time_type
 from decimal import Decimal

--- a/littleutils/__init__.py
+++ b/littleutils/__init__.py
@@ -21,8 +21,12 @@ except NameError:
     # noinspection PyShadowingBuiltins
     basestring = str
 
-from collections.abc import Sized, Mapping, Sequence, MutableMapping
-from collections import defaultdict
+try:
+    from collections.abc import Sized, Mapping, Sequence, MutableMapping
+    from collections import defaultdict
+except ImportError:
+    from collections import defaultdict, Sized, Mapping, Sequence, MutableMapping
+
 from contextlib import contextmanager
 from datetime import datetime, date, time as time_type
 from decimal import Decimal


### PR DESCRIPTION
```
>>> from collections import Sized, defaultdict, Mapping, Sequence, MutableMapping
__main__:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
```