### PR TITLE
Fix invalid regex escape syntax in ensure_list_if_string

### DIFF
--- a/littleutils/__init__.py
+++ b/littleutils/__init__.py
@@ -319,7 +319,7 @@ def ensure_list_if_string(x):
     []
     """
     if isinstance(x, basestring):
-        x = list(filter(None, re.split('[,\s]+', x)))
+        x = list(filter(None, re.split(r'[,\s]+', x)))
     return x
 
 


### PR DESCRIPTION
```
.venv/lib/python3.12/site-packages/littleutils/__init__.py:322: SyntaxWarning: invalid escape sequence '\s'
  x = list(filter(None, re.split('[,\s]+', x)))
```

This is a quick fix to address the regex literal escape warning. I got this warning while importing the `sorcery` package.